### PR TITLE
Add an option to ignore debug sections

### DIFF
--- a/web/drop-zone.tsx
+++ b/web/drop-zone.tsx
@@ -16,6 +16,12 @@ const options = [
     default: true,
     caption: "Make Rust functions humanly readable.",
   },
+  {
+    flag: "--ignore-debug-sections",
+    name: "Ignore Debug Sections",
+    default: true,
+    caption: "Ignore debug sections in the Wasm file.",
+  },
 ];
 
 function dbg(arg) {


### PR DESCRIPTION
Add an option to ignore debug sections, which otherwise consume a considerable portion of the flamegraph and obscure the impact of actual code.