### PR TITLE
Wasm components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,13 +8,8 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
- "cpp_demangle",
  "fallible-iterator",
  "gimli",
- "memmap2",
- "object",
- "rustc-demangle",
- "smallvec",
 ]
 
 [[package]]
@@ -323,15 +318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
-name = "memmap2"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,12 +412,6 @@ name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
-
-[[package]]
-name = "smallvec"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -356,7 +359,7 @@ dependencies = [
  "flate2",
  "memchr",
  "ruzstd",
- "wasmparser",
+ "wasmparser 0.202.0",
 ]
 
 [[package]]
@@ -522,6 +525,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.207.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19bb9f8ab07616da582ef8adb24c54f1424c7ec876720b7da9db8ec0626c92c"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "hashbrown",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "wasmphobia"
 version = "0.1.0"
 dependencies = [
@@ -532,6 +548,7 @@ dependencies = [
  "inferno",
  "object",
  "rustc-demangle",
+ "wasmparser 0.207.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ lto = true
 codegen-units = 1
 
 [dependencies]
-addr2line = "0.22.0"
+addr2line = { version = "0.22.0", default-features = false, features = ["fallible-iterator", "std"] }
 anyhow = "1.0.82"
 clap = { version = "4.5.4", features = ["derive"] }
 cpp_demangle = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = "1.0.82"
 clap = { version = "4.5.4", features = ["derive"] }
 cpp_demangle = "0.4.3"
 inferno = { version = "0.11.19", default-features = false, features = ["nameattr"] }
+wasmparser = "0.207.0"
 
 # Exposing transitive dependencies of `addr2line`
 object = { version = "0.35.0", features = ["wasm"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     io::{Read, Write},
+    ops::Range,
     path::PathBuf,
 };
 
@@ -58,14 +59,14 @@ impl From<Args> for inferno::flamegraph::Options<'static> {
     }
 }
 
-struct Segment {
+struct Section {
     name: String,
     start: u64,
     end: u64,
     mapped: u64,
 }
 
-impl Segment {
+impl Section {
     fn size(&self) -> u64 {
         self.end - self.start
     }
@@ -81,27 +82,7 @@ fn main() -> anyhow::Result<()> {
     };
     let module_size = input_data.len();
 
-    let dwarf = parse_wasm(&input_data).context("Parsing Wasm")?;
-    // let wasm_file = object::wasm::WasmFile::parse(input_data.as_slice())?;
-
-    // let mut segments: Vec<_> = wasm_file
-    //     .sections()
-    //     .filter_map(|s| {
-    //         let name = s.name().ok()?.to_string();
-    //         if !args.show_debug_sections && name.starts_with(".debug_") {
-    //             return None;
-    //         }
-    //         let (start, end) = s.file_range()?;
-    //         Some(Segment {
-    //             name,
-    //             start,
-    //             end,
-    //             mapped: 0,
-    //         })
-    //     })
-    //     .collect();
-    let mut segments: Vec<Segment> = vec![];
-
+    let (dwarf, mut sections) = parse_wasm(&input_data).context("Parsing Wasm")?;
     let context = addr2line::Context::from_dwarf(dwarf).context("Constructing address mapping")?;
 
     let mut contributors = HashMap::new();
@@ -110,7 +91,7 @@ fn main() -> anyhow::Result<()> {
     )?;
     for (map_start, size, loc) in locations.into_iter().rev() {
         let map_end = map_start + size;
-        let section_name = if let Some(section) = segments
+        let section_name = if let Some(section) = sections
             .iter_mut()
             .find(|s| s.start <= map_start && s.end > map_end)
         {
@@ -134,7 +115,7 @@ fn main() -> anyhow::Result<()> {
         *contributors.entry(key).or_insert(0) += size;
     }
 
-    for segment in segments {
+    for segment in sections {
         let key = format!("@section: {};<no mapping info>", segment.name);
         *contributors.entry(key).or_insert(0) += segment.size() - segment.mapped;
     }
@@ -149,24 +130,61 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn parse_wasm<'a>(buf: &'a [u8]) -> anyhow::Result<Dwarf<EndianSlice<'a, LittleEndian>>> {
-    use wasmparser::{Parser, Payload};
+fn parse_wasm<'a>(
+    buf: &'a [u8],
+) -> anyhow::Result<(Dwarf<EndianSlice<'a, LittleEndian>>, Vec<Section>)> {
+    use wasmparser::{Parser, Payload, Payload::*};
 
     static EMPTY_SECTION: &[u8] = &[];
 
     let parser = Parser::new(0);
     let mut dwarf_sections: HashMap<&'a str, &'a [u8]> = HashMap::new();
+    let mut sections = vec![];
     for payload in parser.parse_all(buf) {
-        match payload? {
-            Payload::CustomSection(section) => {
+        let (name, range) = match payload? {
+            CustomSection(section) => {
                 let name = section.name();
                 if name.starts_with(".debug") {
                     dwarf_sections.insert(name, section.data());
                 }
+                let start: usize = section.data_offset();
+                let end = start + section.data().len();
+                (name.to_string(), Range { start, end })
             }
+
+            TypeSection(s) => ("type".to_string(), s.range()),
+            ImportSection(s) => ("import".to_string(), s.range()),
+            FunctionSection(s) => ("function".to_string(), s.range()),
+            TableSection(s) => ("table".to_string(), s.range()),
+            MemorySection(s) => ("memory".to_string(), s.range()),
+            TagSection(s) => ("tag".to_string(), s.range()),
+            GlobalSection(s) => ("global".to_string(), s.range()),
+            ExportSection(s) => ("export".to_string(), s.range()),
+            ElementSection(s) => ("element".to_string(), s.range()),
+            DataSection(s) => ("data".to_string(), s.range()),
+            CodeSectionStart { range, .. } => ("code".to_string(), range),
+            InstanceSection(s) => ("instance".to_string(), s.range()),
+            CoreTypeSection(s) => ("core type".to_string(), s.range()),
+            // FIXME: Is recursion needed here?
+            ComponentSection {
+                unchecked_range, ..
+            } => ("component".to_string(), unchecked_range),
+            ComponentInstanceSection(s) => ("component instance".to_string(), s.range()),
+            ComponentAliasSection(s) => ("component alias".to_string(), s.range()),
+            ComponentTypeSection(s) => ("component type".to_string(), s.range()),
+            ComponentCanonicalSection(s) => ("component canonical".to_string(), s.range()),
+            ComponentImportSection(s) => ("component import".to_string(), s.range()),
+            ComponentExportSection(s) => ("component export".to_string(), s.range()),
+
             Payload::End(_) => break,
-            _ => {}
+            _ => continue,
         };
+        sections.push(Section {
+            name,
+            start: range.start.try_into().unwrap(),
+            end: range.end.try_into().unwrap(),
+            mapped: 0,
+        });
     }
 
     let dwarf = Dwarf::load(|section_id| -> anyhow::Result<_> {
@@ -176,7 +194,7 @@ fn parse_wasm<'a>(buf: &'a [u8]) -> anyhow::Result<Dwarf<EndianSlice<'a, LittleE
         Ok(EndianSlice::new(data, LittleEndian))
     })?;
 
-    Ok(dwarf)
+    Ok((dwarf, sections))
 }
 
 fn functions_for_address<R: addr2line::gimli::Reader>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,9 @@ fn main() -> anyhow::Result<()> {
     let module_size = input_data.len();
 
     let (dwarf, mut sections) = parse_wasm(&input_data).context("Parsing Wasm")?;
+    if !args.show_debug_sections {
+        sections.retain(|sect| !sect.name.starts_with(".debug"));
+    }
     let context = addr2line::Context::from_dwarf(dwarf).context("Constructing address mapping")?;
 
     let mut contributors = HashMap::new();


### PR DESCRIPTION
I am using `wasmparser` directly, rather than relying on the `WasmFile` wrapper in `addr2line`, which allows me to handle Wasm modules that use the component model.

@yoshuawuyts Can you give this a spin? :) Especially curious if me not recursing for nested components is a big deal wrt how useful the flame graph is.